### PR TITLE
feat: [QAAU-0000] Support Json Capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepublishOnly": "run-s rebuild",
     "reinstall": "run-s clean ci",
     "rebuild": "run-s clean:artifacts build:all",
-    "start": "appium",
+    "start": "appium -p 4724 -pa /wd/hub",
     "sync-pkgs": "run-p sync-pkgs:*",
     "sync-pkgs:appium-readme": "sync-monorepo-packages --force --no-package-json --packages=packages/appium README.md",
     "sync-pkgs:common-fields": "sync-monorepo-packages --fields=author,license,bugs,homepage,engines",

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -218,6 +218,7 @@ class AppiumDriver extends DriverCore {
    * @param {DriverData[]} [driverData]
    */
   async createSession(jsonwpCaps, reqCaps, w3cCapabilities, driverData) {
+    w3cCapabilities = w3cCapabilities || jsonwpCaps;
     const defaultCapabilities = _.cloneDeep(this.args.defaultCapabilities);
     const defaultSettings = pullSettings(defaultCapabilities);
     jsonwpCaps = _.cloneDeep(jsonwpCaps);


### PR DESCRIPTION
- With current setup of https://github.com/pomelofashion/regression-tests-mobile, the `wd` lib doesn't support w3c capabilities yet. 
- So we add a fallback logic in appium server
- This should be fixed by `wd` in up coming version.